### PR TITLE
Update db connection size

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -16,6 +16,8 @@ spring:
     url: jdbc:${DATABASE_URL} # NAME MUST NOT CHANGE
     username: ${POSTGRES_USER}
     password: ${POSTGRES_PASSWORD}
+    hikari:
+      maximum-pool-size: 4
 
   jpa:
     hibernate:


### PR DESCRIPTION
Vi har kun 10 connections på scalingo, så når vi deployer bruger vi "20" og derfor fejler den. Derfor ændrer jeg det til 4, så når vi deployer bruger vi max 8